### PR TITLE
Lower case hackathon name in header

### DIFF
--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -11,7 +11,7 @@ export default function App({ Component, pageProps }: AppProps) {
     <>
       <Head>
        <link rel="shortcut icon" type="image/x-icon" sizes="16x16 24x24 32x32 48x48 64x64" href="/favicon.ico" />
-        <title>GuadalaHacks</title>
+        <title>guadalahacks</title>
         <meta name="description" content="El hackatón estudiantil del occidente de México" />
         <meta name="keywords" content="hackathon, guadalajara, guadalahacks, hack, coding, programming, programación, hackatón, hackaton, hackathon, student, computacion, estudiante" />
         <meta name="og:image" content="/banner.png" />

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -3,7 +3,7 @@ import { Html, Head, Main, NextScript } from 'next/document'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-    title: 'GuadalaHacks',
+    title: 'guadalahacks',
     description: 'El hackathon estudiantil más grande del occidente de México',
   }
 


### PR DESCRIPTION
## Description
Webpage title all in lowercase so web browser tabs match the naming convention of the event.

## Milestones
N/A

## Test Plan
Local run, visual inspection.
Before and after:

<img width="140" alt="Screenshot 2024-10-26 at 15 36 39" src="https://github.com/user-attachments/assets/9b266c22-d118-43a1-b79d-862f7c7b23af">
