### PR TITLE
Comment out unconfirmed Partners

### DIFF
--- a/frontend/src/sections/Partners.tsx
+++ b/frontend/src/sections/Partners.tsx
@@ -14,13 +14,13 @@ export const Partners: React.FC = () => {
       </h1>
       <div className="partners-logos">
         <PartnerLogo src="./tec.png" alt="Tecnológico de Monterrey" />
-        <PartnerLogo src="./github.png" alt="GitHub" link="https://github.com/features/copilot" wording={getLocalizedString("partners_github_wording")} />
+        {/* <PartnerLogo src="./github.png" alt="GitHub" link="https://github.com/features/copilot" wording={getLocalizedString("partners_github_wording")} /> */}
         <PartnerLogo src="./life.png" alt="LiFE TEC" />
         <PartnerLogo src="./emprendimiento_tec.png" alt={getLocalizedString("partners_emprendimiento_alt")} />
         <PartnerLogo src="./eic.png" alt={getLocalizedString("partners_eic_alt")} />
-        <PartnerLogo src="./wtm_2.png" alt="Women Techmakers" />
-        <PartnerLogo src="./gce.png" alt="GitHub Campus Experts" link="https://education.github.com/benefits?utm_source=2024-04-18-Guadalahacks" wording={getLocalizedString("partners_gce_wording")}/>
-        <PartnerLogo src="./blend.png" alt="Blend" link="https://blend.com/company/careers/emerging-talent/" wording={getLocalizedString("partners_blend_wording")}/>
+        {/* <PartnerLogo src="./wtm_2.png" alt="Women Techmakers" /> */}
+        {/* <PartnerLogo src="./gce.png" alt="GitHub Campus Experts" link="https://education.github.com/benefits?utm_source=2024-04-18-Guadalahacks" wording={getLocalizedString("partners_gce_wording")}/> */}
+        {/* <PartnerLogo src="./blend.png" alt="Blend" link="https://blend.com/company/careers/emerging-talent/" wording={getLocalizedString("partners_blend_wording")}/> */}
       </div>
     </div>
   );


### PR DESCRIPTION
## Description

Commented out GitHub, Women TechMakers, Blend, GitHub Campus Experts logos in the Partners section of the `frontend/src/sections/Partners.tsx` file.
| Before | After |
| --- | --- |
| <img width="1624" alt="Screenshot 2025-01-17 at 17 25 43" src="https://github.com/user-attachments/assets/a1698846-3ea3-4e91-b0a5-429b0316bedf" /> | <img width="1624" alt="Screenshot 2025-01-17 at 17 24 23" src="https://github.com/user-attachments/assets/96b77b63-8fc9-4c90-aed8-55794d440de4" /> |