### PR TITLE
Fix navbar button name and point it to the Sponsors section

### DIFF
--- a/frontend/src/app/localization.tsx
+++ b/frontend/src/app/localization.tsx
@@ -311,8 +311,8 @@ export const elementLocalization: ElementLocalization = {
         en: <>Contact</>
     },
     navbar_partners: {
-        es: <>Partners</>,
-        en: <>Partners</>
+        es: <>Patrocinadores</>,
+        en: <>Sponsors</>
     },
     navbar_faq: {
         es: <>FAQ</>,

--- a/frontend/src/sections/Partners.tsx
+++ b/frontend/src/sections/Partners.tsx
@@ -9,8 +9,8 @@ const valeraLight = Varela_Round({ weight: "400", subsets: ["latin"] });
 export const Partners: React.FC = () => {
   const [language, _] = languageState.useState();
   return (
-    <>
-      <div className={"partners-container " + valeraLight.className} id='sponsors'>
+    <div id='partners'>
+      <div className={"partners-container " + valeraLight.className}>
         <h1 className="partners-title">
           {getLocalizedElement("sponsors_title", language)}
         </h1>
@@ -19,7 +19,7 @@ export const Partners: React.FC = () => {
           <PartnerLogo src="./hp.png" alt="HP" />
         </div>
       </div>
-      <div className={"partners-container " + valeraLight.className} id='partners'>
+      <div className={"partners-container " + valeraLight.className}>
         <h1 className="partners-title">
           {getLocalizedElement("partners_title", language)}
         </h1>
@@ -30,6 +30,6 @@ export const Partners: React.FC = () => {
           <PartnerLogo src="./eic.png" alt={getLocalizedString("partners_eic_alt", language)} />
         </div>
       </div>
-    </>
+    </div>
   );
 };


### PR DESCRIPTION
## Description
- Rename "Partners/Partners" button to "Sponsors/Patrocinadores"
- Point button to start of Sponsors section (as opposed to skipping to Partners subsection)

## Test Plan
- `npm run dev` locally, validate button moves view to correct location

Closes #32 