### PR TITLE
Use <Image /> for all image resources

### DIFF
--- a/frontend/src/components/Contact.tsx
+++ b/frontend/src/components/Contact.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import './Contact.scss'
 import { getLocalizedElement, languageState } from '@/app/locale';
-
-
+import Image from 'next/image';
+import img_googlemaps from './../../public/googlemaps.png';
+import img_applemaps from './../../public/applemaps.png';
 
 
 
@@ -17,10 +18,10 @@ const Contact: React.FC = () => {
             <p>Av. Gral. Ramón Corona 2514<br />Colonia Nuevo México, 45201<br />Zapopan, Jal., México</p>
             <div className="maps-links">
                 <a href="https://maps.app.goo.gl/pZdnoWDcySrFbRao6" target="_blank" rel="noopener noreferrer">
-                    <img src="googlemaps.png" alt="Google Maps" />
+                    <Image src={img_googlemaps} alt="Google Maps" />
                 </a>
                 <a href="https://maps.apple.com/?ll=20.733860,-103.456890&q=Instituto%20Tecnologico%20y%20de%20Estudios%20Superiores%20de%20Monterrey&t=m" target="_blank" rel="noopener noreferrer">
-                    <img src="applemaps.png" alt="Apple Maps" />
+                    <Image src={img_applemaps} alt="Apple Maps" />
                 </a>
             </div>
 

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -7,7 +7,9 @@ import { faEnvelope } from '@fortawesome/free-solid-svg-icons'
 import { Varela_Round } from 'next/font/google'
 import { faHeart } from '@fortawesome/free-solid-svg-icons/faHeart';
 import Link from 'next/link';
+import Image from 'next/image';
 import { getLocalizedElement, languageState } from '@/app/locale';
+import img_logo_outline from './../../public/logo-outline.png';
 const valeraLight = Varela_Round({weight: "400", subsets: ["latin"]})
 
 const Footer: React.FC = () => {
@@ -18,7 +20,7 @@ const Footer: React.FC = () => {
         <div className="footer-row">
             {/* Copyright Notice */}
             <div className="footer-column">
-                <img src="./logo-outline.png" alt="logo" className="footer-logo" width={150}/>
+                <Image src={img_logo_outline} alt="logo" className="footer-logo" width={150}/>
             </div>
 
             {/* Social Media Icons */}

--- a/frontend/src/components/NavigationBar.css
+++ b/frontend/src/components/NavigationBar.css
@@ -21,7 +21,7 @@
 }
 
 .nav-logo{
-    margin: 0 !important;
+    margin: 10px 0 !important;
     display: inline;
     padding: 0;
 }

--- a/frontend/src/components/NavigationBar.tsx
+++ b/frontend/src/components/NavigationBar.tsx
@@ -2,8 +2,10 @@ import React, { useState } from 'react';
 import { Varela_Round } from 'next/font/google'
 import './NavigationBar.css'
 import Link from 'next/link';
+import Image from 'next/image';
 import { getLocalizedElement, languageState } from '@/app/locale';
 import LanguageToggle from './LanguageToggle';
+import img_logo from './../../public/logo.png';
 
 const valeraLight = Varela_Round({weight: "400", subsets: ["latin"]})
 
@@ -23,7 +25,7 @@ const NavigationBar: React.FC = () => {
           {/* Logo section */}
           <Link href="/" className='nav-logo-anchor'>
             <div className="flex items-center">
-              <img src="/logo.png" alt="logo" className="h-20 nav-logo" />
+              <Image src={img_logo} alt="logo" className="h-20 nav-logo" />
               <div className='ml-6 text-4xl font-semibold desktop-logo-text'>
                 <span className={'logo-text-nav'+' '+valeraClass}>{getLocalizedElement("navbar_title", language)}</span>
               </div>

--- a/frontend/src/components/NavigationBar.tsx
+++ b/frontend/src/components/NavigationBar.tsx
@@ -25,7 +25,7 @@ const NavigationBar: React.FC = () => {
           {/* Logo section */}
           <Link href="/" className='nav-logo-anchor'>
             <div className="flex items-center">
-              <Image src={img_logo} alt="logo" className="h-20 nav-logo" />
+              <Image src={img_logo} alt="logo" className="w-10 nav-logo" />
               <div className='ml-6 text-4xl font-semibold desktop-logo-text'>
                 <span className={'logo-text-nav'+' '+valeraClass}>{getLocalizedElement("navbar_title", language)}</span>
               </div>

--- a/frontend/src/components/PartnerLogo.tsx
+++ b/frontend/src/components/PartnerLogo.tsx
@@ -1,7 +1,8 @@
 import { getLocalizedString, languageState } from "@/app/locale";
+import Image, { StaticImageData } from 'next/image';
 
 interface PartnerLogoProps {
-    src: string;
+    src: StaticImageData;
     alt: string;
     link?: string;
     wording?: string;
@@ -11,7 +12,7 @@ export const PartnerLogo: React.FC<PartnerLogoProps> = ({ src, alt, link, wordin
   const [language, _] = languageState.useState();
     return (
       <div className="partner-logo-container">
-        <img src={src} alt={alt} className="partner-logo" />
+        <Image src={src} alt={alt} className="partner-logo" />
         {link && (
           <a href={link} target="_blank" rel="noopener noreferrer" className="partner-link">
             {wording || getLocalizedString("partnerLogo_defaultWording", language)}

--- a/frontend/src/sections/LandingPage.css
+++ b/frontend/src/sections/LandingPage.css
@@ -1,6 +1,6 @@
 .gradient-container {
     background: linear-gradient(to right, #E4007C, #FF8B74);
-    height: calc(100vh - 96px);
+    height: calc(100vh - 86px);
     min-height: 490px;
     display: flex;
     flex-direction: column;

--- a/frontend/src/sections/LandingPage.tsx
+++ b/frontend/src/sections/LandingPage.tsx
@@ -4,6 +4,8 @@ import './LandingPage.css'; // Import the CSS
 import { getLocalizedElement, languageState } from '@/app/locale';
 import { Varela_Round } from 'next/font/google'
 import Link from 'next/link';
+import Image from 'next/image';
+import img_logo_outline from './../../public/logo-outline.png';
 
 const valeraLight = Varela_Round({weight: "400", subsets: ["latin"]})
 
@@ -16,7 +18,7 @@ const LandingPage: React.FC = () => {
     <div className="gradient-container">
 
       <div className='logo-container'>
-        <img src="./logo-outline.png" alt="logo" className="logo" />
+        <Image src={img_logo_outline} alt="logo" className="logo" />
         <span className={'logo-text-landing'+' '+valeraLight.className}>
           {getLocalizedElement("landing_title", language)}
         </span>

--- a/frontend/src/sections/Partners.tsx
+++ b/frontend/src/sections/Partners.tsx
@@ -3,6 +3,12 @@ import './Partners.scss';
 import { getLocalizedElement, getLocalizedString, languageState } from '@/app/locale';
 import { Varela_Round } from 'next/font/google';
 import { PartnerLogo } from '../components/PartnerLogo'; // Import the new component
+import img_intel from './../../public/intel.png';
+import img_hp from './../../public/hp.png';
+import img_tec from './../../public/tec.png';
+import img_life from './../../public/life.png';
+import img_emprendimiento_tec from './../../public/emprendimiento_tec.png';
+import img_eic from './../../public/eic.png';
 
 const valeraLight = Varela_Round({ weight: "400", subsets: ["latin"] });
 
@@ -15,8 +21,8 @@ export const Partners: React.FC = () => {
           {getLocalizedElement("sponsors_title", language)}
         </h1>
         <div className="partners-logos">
-          <PartnerLogo src="./intel.png" alt="Intel" />
-          <PartnerLogo src="./hp.png" alt="HP" />
+          <PartnerLogo src={img_intel} alt="Intel" />
+          <PartnerLogo src={img_hp} alt="HP" />
         </div>
       </div>
       <div className={"partners-container " + valeraLight.className}>
@@ -24,10 +30,10 @@ export const Partners: React.FC = () => {
           {getLocalizedElement("partners_title", language)}
         </h1>
         <div className="partners-logos">
-          <PartnerLogo src="./tec.png" alt="Tecnológico de Monterrey" />
-          <PartnerLogo src="./life.png" alt="LiFE TEC" />
-          <PartnerLogo src="./emprendimiento_tec.png" alt={getLocalizedString("partners_emprendimiento_alt", language)} />
-          <PartnerLogo src="./eic.png" alt={getLocalizedString("partners_eic_alt", language)} />
+          <PartnerLogo src={img_tec} alt="Tecnológico de Monterrey" />
+          <PartnerLogo src={img_life} alt="LiFE TEC" />
+          <PartnerLogo src={img_emprendimiento_tec} alt={getLocalizedString("partners_emprendimiento_alt", language)} />
+          <PartnerLogo src={img_eic} alt={getLocalizedString("partners_eic_alt", language)} />
         </div>
       </div>
     </div>

--- a/frontend/src/sections/PhotoGallery.tsx
+++ b/frontend/src/sections/PhotoGallery.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import './PhotoGallery.css';
 import { getLocalizedString, languageState } from '@/app/locale';
+import Image from 'next/image';
+import img_collage2024 from './../../public/collage2024.png';
 
 export const PhotoGallery: React.FC = () => {
   const [language, _] = languageState.useState();
   return (
     <div className="gallery-container">
-      <img src="./collage2024.png" alt={getLocalizedString("gallery_photo_alt", language)} className="single-picture" />
+      <Image src={img_collage2024} alt={getLocalizedString("gallery_photo_alt", language)} className="single-picture" />
     </div>
   );
 };


### PR DESCRIPTION
## Description
- Swap all `img` for `Image`
- Statically import all images
- Change class `h-20` for `h-10` in navbar logo
- Add 10px top and bottom margin to navbar logo
- Make gradient container 10px taller to compensate

## Resources
[Next.js `Image` docs](https://nextjs.org/docs/pages/api-reference/components/image)

## Test Plan
| Old | New |
| --- | --- |
| <img width="1624" alt="Screenshot 2025-03-29 at 21 18 45" src="https://github.com/user-attachments/assets/12560c38-94a6-4ad2-9bde-0f701bc5b647" /><img width="613" alt="Screenshot 2025-03-29 at 21 17 59" src="https://github.com/user-attachments/assets/8acc4efa-5784-4591-a28c-95be0b2700b0" /> | <img width="1624" alt="Screenshot 2025-03-29 at 21 16 52" src="https://github.com/user-attachments/assets/7d5d2432-30ab-4d6d-ade4-a3428c606563" /><img width="613" alt="Screenshot 2025-03-29 at 21 16 32" src="https://github.com/user-attachments/assets/1534d8f1-eea3-4d6b-b4a0-e8717614f68f" /> |
| | |

Closes #34 